### PR TITLE
To replace `close()` with `destroy()`

### DIFF
--- a/webcodecs/mstp/index.html
+++ b/webcodecs/mstp/index.html
@@ -44,7 +44,7 @@ document.addEventListener('DOMContentLoaded', function(event) {
         if (stopped) {
           frameReader.releaseLock();
           processor.readable.cancel();
-          value.close();
+          value.destroy();
           log.value += "Stopped;"
           return
         }
@@ -53,7 +53,7 @@ document.addEventListener('DOMContentLoaded', function(event) {
             log.value += "Read 20 frames. ";
         }
 
-        value.close();
+        value.destroy();
         frameReader.read().then(processFrame);
     })
   }).catch(function(err) { log.value += err.name + ": " + err.message; });


### PR DESCRIPTION
Just a quick fix.
I'd appreciate it if you would confirm and merge it.